### PR TITLE
Atlab 7846

### DIFF
--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -109,13 +109,12 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
     } catch (UnavailableException e) {
       return IdUtils.INVALID_WORKER_ID;
     }
-
   /*
   qiniu:   get the first HashMap of workerAddress and blocks---workerAddressCounts
            get the secondary HashMap of workerAddress and workerId---workerAddressId
   */
-    Map<String,Integer> workerAddressCounts=new HashMap<>();
-    Map<String,Long> workerAddressId=new HashMap<>();
+    Map<String,Integer> workerAddressCounts = new HashMap<>();
+    Map<String,Long> workerAddressId = new HashMap<>();
 
     List<FileBlockInfo> blockInfoList;
     try {
@@ -124,10 +123,10 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
       for (FileBlockInfo fileBlockInfo : blockInfoList) {
         for (BlockLocation blockLocation : fileBlockInfo.getBlockInfo().getLocations()) {
           if (workerAddressCounts.containsKey(blockLocation.getWorkerAddress().toString())) {
-              workerAddressCounts.put(blockLocation.getWorkerAddress().toString(),
-              workerAddressCounts.get(blockLocation.getWorkerAddress().toString()) + 1);
+            workerAddressCounts.put(blockLocation.getWorkerAddress().toString(),
+            workerAddressCounts.get(blockLocation.getWorkerAddress().toString()) + 1);
           } else {
-              workerAddressCounts.put(blockLocation.getWorkerAddress().toString(), 1);
+            workerAddressCounts.put(blockLocation.getWorkerAddress().toString(), 1);
           }
           workerAddressId.put(blockLocation.getWorkerAddress().toString(),blockLocation.getWorkerId());
           if (workerAddressCounts.get(blockLocation.getWorkerAddress().toString()) == blockInfoList.size()) {
@@ -151,23 +150,19 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
 
     //qiniu: get the worker with most blocks.
     Map<String,Integer> worker = new LinkedHashMap<>();
-    List<String> list=new ArrayList<String>();
-    workerAddressCounts.entrySet().stream().sorted(Map.Entry.<String,Integer>comparingByValue().reversed()).
-    forEachOrdered(x -> worker.put(x.getKey(), x.getValue()));
-    int blockNum=worker.entrySet().iterator().next().getValue(); 
-    for(Map.Entry<String,Integer> entry:worker.entrySet()){
-            if(entry.getValue()!=blockNum){
-               break;
-            }
-            list.add(entry.getKey());
+    List<String> list = new ArrayList<String>();
+    workerAddressCounts.entrySet().stream().sorted(Map.Entry.<String,Integer>comparingByValue().reversed())
+      .forEachOrdered(x -> worker.put(x.getKey(), x.getValue()));
+    int blockNum = worker.entrySet().iterator().next().getValue();
+    for(Map.Entry<String,Integer> entry : worker.entrySet()){
+      if(entry.getValue() != blockNum){
+        break;
+      }
+      list.add(entry.getKey());
     }
 
-    if(list.size()==1){
-      return workerAddressId.get(list.get(0));
-    }
-    Collections.sort(list);
-    String maxAddress=list.get(list.size()-1);
-    return workerAddressId.get(maxAddress);
+    String uniqueAddress = list.get((int)fileId % list.size());
+    return workerAddressId.get(uniqueAddress);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -160,7 +160,7 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
       }
       list.add(entry.getKey());
     }
-
+    Collections.sort(list);
     String uniqueAddress = list.get((int)fileId % list.size());
     return workerAddressId.get(uniqueAddress);
   }

--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -71,7 +71,6 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
       throws AlluxioException, UnavailableException {
     // find the worker
     long workerId = getWorkerStoringFile(path);
-
     if (workerId == IdUtils.INVALID_WORKER_ID) {
       LOG.error("No worker found to schedule async persistence for file " + path);
       return;
@@ -95,8 +94,6 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
   private long getWorkerStoringFile(AlluxioURI path)
       throws FileDoesNotExistException, AccessControlException, UnavailableException {
     long fileId = mFileSystemMasterView.getFileId(path);
-    //qiniu: initialize the return workerId
-    long workerId=0l;
     try {
       if (mFileSystemMasterView.getFileInfo(fileId).getLength() == 0) {
         // if file is empty, return any worker
@@ -113,11 +110,12 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
       return IdUtils.INVALID_WORKER_ID;
     }
 
-    Map<Long, Integer> workerBlockCounts = new HashMap<>();
-    //qiniu: workerAddress:blocks
+  /*
+  qiniu:   get the first HashMap of workerAddress and blocks---workerAddressCounts
+           get the secondary HashMap of workerAddress and workerId---workerAddressId
+  */
     Map<String,Integer> workerAddressCounts=new HashMap<>();
-     //qiniu: workerId:workerAddress
-    Map<Long,String> workerIdAddress=new HashMap<>();
+    Map<String,Long> workerAddressId=new HashMap<>();
 
     List<FileBlockInfo> blockInfoList;
     try {
@@ -125,26 +123,16 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
 
       for (FileBlockInfo fileBlockInfo : blockInfoList) {
         for (BlockLocation blockLocation : fileBlockInfo.getBlockInfo().getLocations()) {
-          if (workerBlockCounts.containsKey(blockLocation.getWorkerId())) {
-            workerBlockCounts.put(blockLocation.getWorkerId(),
-                workerBlockCounts.get(blockLocation.getWorkerId()) + 1);
-          } else {
-            workerBlockCounts.put(blockLocation.getWorkerId(), 1);
-          }
-          //qiniu:get the the blocks of every WorkerAddress
           if (workerAddressCounts.containsKey(blockLocation.getWorkerAddress().toString())) {
               workerAddressCounts.put(blockLocation.getWorkerAddress().toString(),
               workerAddressCounts.get(blockLocation.getWorkerAddress().toString()) + 1);
           } else {
               workerAddressCounts.put(blockLocation.getWorkerAddress().toString(), 1);
           }
-
-          // all the blocks of a file must be stored on the same worker
-          if (workerBlockCounts.get(blockLocation.getWorkerId()) == blockInfoList.size()) {
+          workerAddressId.put(blockLocation.getWorkerAddress().toString(),blockLocation.getWorkerId());
+          if (workerAddressCounts.get(blockLocation.getWorkerAddress().toString()) == blockInfoList.size()) {
             return blockLocation.getWorkerId();
           }
-          //qiniu:get the map workerId:workerAddress
-          workerIdAddress.put(blockLocation.getWorkerId(),blockLocation.getWorkerAddress().toString());        
         }
       }
     } catch (FileDoesNotExistException e) {
@@ -156,44 +144,30 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
     } catch (UnavailableException e) {
       return IdUtils.INVALID_WORKER_ID;
     }
-
-    if (workerBlockCounts.size() == 0) {
+    if (workerAddressCounts.size() == 0) {
       LOG.error("The file " + path + " does not exist on any worker");
       return IdUtils.INVALID_WORKER_ID;
     }
 
-    // qiniu PMW get worker with most blocks
+    //qiniu: get the worker with most blocks.
     Map<String,Integer> worker = new LinkedHashMap<>();
     List<String> list=new ArrayList<String>();
-    //qiniu :sort the map of  workerAddressCounts and put it into map worker
     workerAddressCounts.entrySet().stream().sorted(Map.Entry.<String,Integer>comparingByValue().reversed()).
     forEachOrdered(x -> worker.put(x.getKey(), x.getValue()));
-    //qiniu: blockNum is the max value of blocks
     int blockNum=worker.entrySet().iterator().next().getValue(); 
-    //qiniu: get the workerAddress of the max blocks
-    Iterator iter=workerAddressCounts.entrySet().iterator();
-    while(iter.hasNext()){
-            Map.Entry item=(Map.Entry)iter.next();
-            if((Integer)item.getValue()==blockNum){
-              //qiniu:put the workerAddress into the list
-              list.add((String)item.getKey());
+    for(Map.Entry<String,Integer> entry:worker.entrySet()){
+            if(entry.getValue()!=blockNum){
+               break;
             }
+            list.add(entry.getKey());
     }
-    //qiniu:sort the workerAddress and find the max workerAddress
+
+    if(list.size()==1){
+      return workerAddressId.get(list.get(0));
+    }
     Collections.sort(list);
     String maxAddress=list.get(list.size()-1);
-    //qiniu:find the workerId  corresponding to the the max workerAddress
-    Iterator iter2=workerIdAddress.entrySet().iterator();
-    while(iter2.hasNext()){
-            Map.Entry item=(Map.Entry)iter2.next();
-            if((String)item.getValue()==maxAddress){
-                   workerId=(long)item.getKey();
-            }
-    } 
-   return workerId;
-
-    //LOG.error("Not all the blocks of file {} stored on the same worker", path);
-    //return IdUtils.INVALID_WORKER_ID;
+    return workerAddressId.get(maxAddress);
   }
 
   /**

--- a/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
+++ b/core/server/master/src/main/java/alluxio/master/file/async/DefaultAsyncPersistHandler.java
@@ -32,9 +32,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -93,6 +95,8 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
   private long getWorkerStoringFile(AlluxioURI path)
       throws FileDoesNotExistException, AccessControlException, UnavailableException {
     long fileId = mFileSystemMasterView.getFileId(path);
+    //qiniu: initialize the return workerId
+    long workerId=0l;
     try {
       if (mFileSystemMasterView.getFileInfo(fileId).getLength() == 0) {
         // if file is empty, return any worker
@@ -110,6 +114,11 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
     }
 
     Map<Long, Integer> workerBlockCounts = new HashMap<>();
+    //qiniu: workerAddress:blocks
+    Map<String,Integer> workerAddressCounts=new HashMap<>();
+     //qiniu: workerId:workerAddress
+    Map<Long,String> workerIdAddress=new HashMap<>();
+
     List<FileBlockInfo> blockInfoList;
     try {
       blockInfoList = mFileSystemMasterView.getFileBlockInfoList(path);
@@ -122,11 +131,20 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
           } else {
             workerBlockCounts.put(blockLocation.getWorkerId(), 1);
           }
+          //qiniu:get the the blocks of every WorkerAddress
+          if (workerAddressCounts.containsKey(blockLocation.getWorkerAddress().toString())) {
+              workerAddressCounts.put(blockLocation.getWorkerAddress().toString(),
+              workerAddressCounts.get(blockLocation.getWorkerAddress().toString()) + 1);
+          } else {
+              workerAddressCounts.put(blockLocation.getWorkerAddress().toString(), 1);
+          }
 
           // all the blocks of a file must be stored on the same worker
           if (workerBlockCounts.get(blockLocation.getWorkerId()) == blockInfoList.size()) {
             return blockLocation.getWorkerId();
           }
+          //qiniu:get the map workerId:workerAddress
+          workerIdAddress.put(blockLocation.getWorkerId(),blockLocation.getWorkerAddress().toString());        
         }
       }
     } catch (FileDoesNotExistException e) {
@@ -145,10 +163,34 @@ public final class DefaultAsyncPersistHandler implements AsyncPersistHandler {
     }
 
     // qiniu PMW get worker with most blocks
-    Map<Long, Integer> workers = new LinkedHashMap<>();
-    workerBlockCounts.entrySet().stream().sorted(Map.Entry.comparingByValue(Comparator.reverseOrder()))
-        .forEachOrdered(x -> workers.put(x.getKey(), x.getValue()));
-    return workers.keySet().iterator().next();
+    Map<String,Integer> worker = new LinkedHashMap<>();
+    List<String> list=new ArrayList<String>();
+    //qiniu :sort the map of  workerAddressCounts and put it into map worker
+    workerAddressCounts.entrySet().stream().sorted(Map.Entry.<String,Integer>comparingByValue().reversed()).
+    forEachOrdered(x -> worker.put(x.getKey(), x.getValue()));
+    //qiniu: blockNum is the max value of blocks
+    int blockNum=worker.entrySet().iterator().next().getValue(); 
+    //qiniu: get the workerAddress of the max blocks
+    Iterator iter=workerAddressCounts.entrySet().iterator();
+    while(iter.hasNext()){
+            Map.Entry item=(Map.Entry)iter.next();
+            if((Integer)item.getValue()==blockNum){
+              //qiniu:put the workerAddress into the list
+              list.add((String)item.getKey());
+            }
+    }
+    //qiniu:sort the workerAddress and find the max workerAddress
+    Collections.sort(list);
+    String maxAddress=list.get(list.size()-1);
+    //qiniu:find the workerId  corresponding to the the max workerAddress
+    Iterator iter2=workerIdAddress.entrySet().iterator();
+    while(iter2.hasNext()){
+            Map.Entry item=(Map.Entry)iter2.next();
+            if((String)item.getValue()==maxAddress){
+                   workerId=(long)item.getKey();
+            }
+    } 
+   return workerId;
 
     //LOG.error("Not all the blocks of file {} stored on the same worker", path);
     //return IdUtils.INVALID_WORKER_ID;


### PR DESCRIPTION
        如果一个文件的block横跨多个worker，挑选拥有block数目最多的worker去做persist。如果两个worker包含的block数目相同，则两次可能会返回不同的worker ID。
       改动代码后每次返回的是唯一的worker ID。
